### PR TITLE
Ignore .ma file

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+# Disables language detection for our very lange .ma binary files 
+*.ma linguist-detectable=false


### PR DESCRIPTION
Fix #18 

Ignore the `.ma` files when GitHub performs its automatic language detection on the repository.